### PR TITLE
codex: usar REACT_APP_API_BASE_URL (.env.example) + helper apiBase + Authorization Bearer

### DIFF
--- a/src/lib/apiBase.js
+++ b/src/lib/apiBase.js
@@ -1,30 +1,30 @@
+// src/lib/apiBase.js
+// Helper compatível com Create React App (usa process.env.REACT_APP_...)
 const DEFAULT_API_BASE = '/api';
-const LOCAL_API_BASE = 'http://localhost:3001';
+const LOCAL_API_HOST = 'http://localhost:3001';
 
-const trimTrailingSlash = (value) => value.replace(/\/+$/, '');
+const appendApiSegment = (value) => {
+  const normalized = value.replace(/\/+$/, ''); // remove barras finais
+  return normalized.toLowerCase().endsWith('/api') ? normalized : `${normalized}/api`;
+};
 
 export const getApiBaseUrl = () => {
   const envUrl = process.env.REACT_APP_API_BASE_URL;
   if (envUrl && envUrl.trim()) {
-    return trimTrailingSlash(envUrl.trim());
+    return appendApiSegment(envUrl.trim());
   }
-
   if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
-    return LOCAL_API_BASE;
+    return appendApiSegment(LOCAL_API_HOST);
   }
-
-  return DEFAULT_API_BASE;
+  return DEFAULT_API_BASE; // fallback para proxy/mesmo domínio
 };
 
 export const resolveApiUrl = (endpoint = '') => {
-  if (!endpoint) {
-    return getApiBaseUrl();
-  }
+  const base = getApiBaseUrl().replace(/\/+$/, ''); // sem barra final
 
-  if (/^https?:\/\//i.test(endpoint)) {
-    return endpoint;
-  }
+  if (!endpoint) return base;
+  if (/^https?:\/\//i.test(endpoint)) return endpoint; // já é absoluto
 
-  const base = getApiBaseUrl();
-  return ${base};
+  const path = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+  return `${base}${path}`;
 };

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,19 +1,30 @@
 import { resolveApiUrl } from '../lib/apiBase';
 
 export async function apiFetch(endpoint, options = {}) {
-  const token = localStorage.getItem('token');
   const url = resolveApiUrl(endpoint);
+  const token = localStorage.getItem('token') || '';
 
   const headers = {
     'Content-Type': 'application/json',
-    ...(token ? { Authorization: Bearer  } : {}),
     ...(options.headers || {}),
   };
+
+  // adiciona Authorization apenas se houver token
+  if (token) {
+    headers.Authorization = token.startsWith('Bearer ')
+      ? token
+      : `Bearer ${token}`;
+  }
+
+  // se body for objeto, serializa (exceto FormData)
+  if (options.body && typeof options.body === 'object' && !(options.body instanceof FormData)) {
+    options = { ...options, body: JSON.stringify(options.body) };
+  }
 
   const response = await fetch(url, {
     ...options,
     headers,
-    // credentials: 'include', // enable if the backend relies on cookies/sessions
+    // credentials: 'include', // habilite se o backend usar cookies/sessões
   });
 
   return response;


### PR DESCRIPTION
adiciona .env.example com REACT_APP_API_BASE_URL

cria src/lib/apiBase.js (resolve base da API com fallback seguro)

refatora src/services/api.js para usar env e header Authorization: Bearer ${token}

build local OK